### PR TITLE
fix Qt6 build

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -18,7 +18,9 @@ int main(int argc, char *argv[]) {
 #endif
 
     QApplication a(argc, argv);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
+#endif
     QApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 
     // Clean


### PR DESCRIPTION
In Qt6, there is no need to set `Qt::AA_DisableWindowContextHelpButton`