### PR TITLE
Use normal red for test results instead of darkRed. fixes #217

### DIFF
--- a/db/Database.cpp
+++ b/db/Database.cpp
@@ -139,7 +139,7 @@ namespace NekoRay {
             } else if (latency < 200) {
                 return Qt::darkYellow;
             } else {
-                return Qt::darkRed;
+                return Qt::red;
             }
         } else {
             return {};


### PR DESCRIPTION
The red color looks good and readable on both light and dark themes but the darkRed is almost unreadable on dark themes. So red is a better choice.