### PR TITLE
Fix sorting empty test results

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -865,6 +865,7 @@ void MainWindow::refresh_proxy_list_impl(const int &id, NekoRay::GroupSortAction
                               }
                               auto get_latency_for_sort = [](int id) {
                                   auto i = NekoRay::profileManager->GetProfile(id)->latency;
+                                  if (i == 0) i = 100000;
                                   if (i < 0) i = 99999;
                                   return i;
                               };


### PR DESCRIPTION
Empty test results show up on top but users expect the lowest latency proxies to be at the top. This commit puts empty results at the bottom.