### PR TITLE
fix ws early data compatibility

### DIFF
--- a/fmt/Bean2CoreObj_box.cpp
+++ b/fmt/Bean2CoreObj_box.cpp
@@ -21,11 +21,7 @@ namespace NekoRay::fmt {
                 }
                 if (ws_early_data_length > 0) {
                     transport["max_early_data"] = ws_early_data_length;
-                    if (ws_early_data_name.isEmpty()) {
-                        transport["early_data_header_name"] = "Sec-WebSocket-Protocol";
-                    } else {
-                        transport["early_data_header_name"] = ws_early_data_name;
-                    }
+                    transport["early_data_header_name"] = ws_early_data_name;
                 }
             } else if (network == "http") {
                 if (!path.isEmpty()) transport["path"] = path;

--- a/fmt/Bean2CoreObj_ray.cpp
+++ b/fmt/Bean2CoreObj_ray.cpp
@@ -26,11 +26,7 @@ namespace NekoRay::fmt {
             }
             if (ws_early_data_length > 0) {
                 ws["maxEarlyData"] = ws_early_data_length;
-                if (ws_early_data_name.isEmpty()) {
-                    ws["earlyDataHeaderName"] = "Sec-WebSocket-Protocol";
-                } else {
-                    ws["earlyDataHeaderName"] = ws_early_data_name;
-                }
+                ws["earlyDataHeaderName"] = ws_early_data_name;
             }
             streamSettings["wsSettings"] = ws;
         } else if (network == "http") {


### PR DESCRIPTION
f53d0aba47d8bd07994ed7c813b1f99031115641 之后，如果early_data_header_name没有被用户设置，将会被设置成xray默认的Sec-WebSocket-Protocol（实际上前面已经判断过xray的情况了），但这不是v2ray或sing-box的默认行为