### PR TITLE
修复一些历史 bug

### DIFF
--- a/fmt/Bean2Link.cpp
+++ b/fmt/Bean2Link.cpp
@@ -76,7 +76,11 @@ namespace NekoRay::fmt {
         QUrl url;
         url.setScheme("ss");
         auto username = method + ":" + password;
-        url.setUserName(username.toUtf8().toBase64(QByteArray::Base64Option::Base64UrlEncoding));
+        if (method == "2022-blake3-aes-256-gcm" || method == "2022-blake3-aes-128-gcm" || method == "2022-blake3-chacha20-poly1305") {
+            url.setUserName(username.toUtf8());
+        } else {
+            url.setUserName(username.toUtf8().toBase64(QByteArray::Base64Option::Base64UrlEncoding));
+        }
         url.setHost(serverAddress);
         url.setPort(serverPort);
         if (!name.isEmpty()) url.setFragment(name);

--- a/libs/package_debian.sh
+++ b/libs/package_debian.sh
@@ -20,17 +20,22 @@ Description: Qt based cross-platform GUI proxy configuration manager (backend: v
 EOF
 
 cat >nekoray/DEBIAN/postinst <<-EOF
-cat >/usr/share/applications/nekoray.desktop<<-END
-[Desktop Entry]
-Name=nekoray
-Version=$version
-Comment=Qt based cross-platform GUI proxy configuration manager (backend: v2ray / sing-box)
-Exec=/opt/nekoray/nekoray -appdata
-Icon=/opt/nekoray/nekoray.png
-Terminal=false
-Type=Application
-Categories=Network;Application;
+if [ -z /usr/share/applications/nekoray.desktop ]; then
+    cat >/usr/share/applications/nekoray.desktop<<-END
+    [Desktop Entry]
+    Name=nekoray
+    Version=$version
+    Comment=Qt based cross-platform GUI proxy configuration manager (backend: v2ray / sing-box)
+    Exec=/opt/nekoray/nekoray -appdata
+    Icon=/opt/nekoray/nekoray.png
+    Terminal=false
+    Type=Application
+    Categories=Network;Application;
 END
+else
+    sed -i "s/^Version=.*/Version=$version/" /usr/share/applications/nekoray.desktop
+fi
+
 update-desktop-database
 EOF
 


### PR DESCRIPTION
* .deb 包裹
  现在安装不会覆盖之前调整过的 .desktop 文件的其他内容
* shadowsocks2022 分享链接
  虽然 #481 中允许导入 shadowsocks2022 链接，但并不支持导出。本次 PR 允许导出标准的 shadowsocks2022 链接。