### PR TITLE
fix route auto complete

### DIFF
--- a/3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp
+++ b/3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp
@@ -81,7 +81,7 @@ namespace Qv2ray::ui::widgets {
         int extra = completion.length() - c->completionPrefix().length();
         tc.movePosition(QTextCursor::Left);
         tc.movePosition(QTextCursor::EndOfWord);
-        tc.insertText(completion.right(extra));
+        tc.insertText(completion.right(extra).toLower());
         setTextCursor(tc);
     }
 


### PR DESCRIPTION
简易路由默认补全的部分为**大写字母**，生成的配置无法使用。

<img src="https://github.com/MatsuriDayo/nekoray/assets/86921203/1818b3e9-b0c4-44cd-9dab-9561940f6b3b" alt="修改前" width="250"/>
<img src="https://github.com/MatsuriDayo/nekoray/assets/86921203/cfa7bc37-9002-4983-9df9-9ec7e0817b25" alt="修改前" width="250"/>