### PR TITLE
Update dialog_manage_routes.ui

### DIFF
--- a/ui/dialog_manage_routes.ui
+++ b/ui/dialog_manage_routes.ui
@@ -204,7 +204,7 @@ For more information, see the document &quot;Configuration/DNS&quot;.</string>
               </item>
               <item>
                <property name="text">
-                <string notr="true">https://one.one.one.one/dns-query</string>
+                <string notr="true">https://cloudflare-dns.com/dns-query</string>
                </property>
               </item>
               <item>


### PR DESCRIPTION
Change the cloudflare dns resolver from one.one.one.one to https://cloudflare-dns.com/dns-query.  

Reason:
Although one * 4 could working correctly, I think we should use the authoritative address given by the official website and curl github repository.

[cloudflare site](https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests)

[curl repository](https://github.com/curl/curl/wiki/DNS-over-HTTPS#publicly-available-servers)