### PR TITLE
Change the default value of Hide Console.

### DIFF
--- a/main/NekoGui_DataStore.hpp
+++ b/main/NekoGui_DataStore.hpp
@@ -150,7 +150,7 @@ namespace NekoGui {
         int vpn_implementation = 0;
         int vpn_mtu = 9000;
         bool vpn_ipv6 = false;
-        bool vpn_hide_console = false;
+        bool vpn_hide_console = true;
         bool vpn_strict_route = false;
         bool vpn_rule_white = false;
         QString vpn_rule_process = "";


### PR DESCRIPTION
Hi there! I think it would be beneficial for us to change the default value of Hide Console to true. This is because many people don't understand the purpose of the console logs, and they can be overwhelming and unnecessary for those unfamiliar with them. By defaulting to Hide Console, we can simplify the interface and create a more user-friendly experience for everyone. Thanks for considering this change!