### PR TITLE
Fix Linux autostart config line endings

### DIFF
--- a/sys/AutoRun.cpp
+++ b/sys/AutoRun.cpp
@@ -149,7 +149,7 @@ bool AutoRun_IsEnabled() {
 #include <QProcessEnvironment>
 #include <QTextStream>
 
-#define NEWLINE "\r\n"
+#define NEWLINE "\n"
 
 //  launchatlogin.cpp
 //  ShadowClash


### PR DESCRIPTION
Linux下.desktop文件应当以\n结尾。

![issue](https://github.com/MatsuriDayo/nekoray/assets/10971397/7b50d4cb-62b2-4793-bec6-f03f65527a1f)
