### PR TITLE
fix: RunGuard not works on Qt6

### DIFF
--- a/3rdparty/RunGuard.hpp
+++ b/3rdparty/RunGuard.hpp
@@ -58,12 +58,12 @@ RunGuard::~RunGuard() {
 }
 
 bool RunGuard::isAnotherRunning(quint64 *data_out) {
-    if (sharedMem.isAttached()) {
+    if (sharedMem.isAttached())
         return false;
-    }
 
     memLock.acquire();
-    const bool isRunning = sharedMem.create(sizeof(quint64));if (!isRunning) {
+    const bool isRunning = sharedMem.attach();
+    if (isRunning) {
         if (data_out != nullptr) {
             memcpy(data_out, sharedMem.data(), sizeof(quint64));
         }
@@ -71,21 +71,15 @@ bool RunGuard::isAnotherRunning(quint64 *data_out) {
     }
     memLock.release();
 
-    return !isRunning;
+    return isRunning;
 }
-
 
 bool RunGuard::tryToRun(quint64 *data_in) {
     if (isAnotherRunning(nullptr)) // Extra check
         return false;
 
     memLock.acquire();
-
-    bool result = sharedMem.attach();
-    // if success attach, attach return false but the error is NoError, magic, love from qt6
-    // qt docs: If false is returned, call error() to determine which error occurred.
-    if (!result) if (sharedMem.error() == QSharedMemory::NoError) result = true;
-
+    const bool result = sharedMem.create(sizeof(quint64));
     if (result) memcpy(sharedMem.data(), data_in, sizeof(quint64));
     memLock.release();
 

--- a/3rdparty/RunGuard.hpp
+++ b/3rdparty/RunGuard.hpp
@@ -75,9 +75,6 @@ bool RunGuard::isAnotherRunning(quint64 *data_out) {
 }
 
 bool RunGuard::tryToRun(quint64 *data_in) {
-    if (isAnotherRunning(nullptr)) // Extra check
-        return false;
-
     memLock.acquire();
     const bool result = sharedMem.create(sizeof(quint64));
     if (result) memcpy(sharedMem.data(), data_in, sizeof(quint64));


### PR DESCRIPTION
之前的https://github.com/MatsuriDayo/nekoray/commit/32ef100cf36076cf672714c68120e0a9141d0106 修复有问题，会造成#1088，此提交修复#1088 并重新修复#955 。

PS: #1089 猜测有可能也是由于这个原因，具体需要有Windows环境的人进行测试。


----

The previous fix https://github.com/MatsuriDayo/nekoray/commit/32ef100cf36076cf672714c68120e0a9141d0106 has issue, causing problem #1088, This commit addresses and resolves #1088, as well as re-fixes #955.

P.S.: It is speculated that #1089 might also be related to the same issue. Testing is needed from someone with a Windows environment.