### PR TITLE
fix: update core asset search dir

### DIFF
--- a/main/NekoGui.cpp
+++ b/main/NekoGui.cpp
@@ -433,6 +433,7 @@ namespace NekoGui {
         search << QApplication::applicationDirPath();
         search << "/usr/share/sing-geoip";
         search << "/usr/share/sing-geosite";
+        search << "/usr/share/sing-box";
         search << "/usr/share/xray";
         search << "/usr/local/share/xray";
         search << "/opt/xray";


### PR DESCRIPTION
Arch Linux side changed the asset install dir from `/usr/share/{pkgbase}` to `/usr/share/sing-box`    [^1] [^2]



[^1]: https://aur.archlinux.org/cgit/aur.git/commit/?h=sing-geosite&id=4dd8d6f30ff33dedc2c9dc8e4346749ae31a23bc
[^2]: https://aur.archlinux.org/cgit/aur.git/commit/?h=sing-geoip&id=8c729a21fbb88b3e285b1925ee81b646b7dd089a