### PR TITLE
Fix issue #1139

### DIFF
--- a/ui/mainwindow_grpc.cpp
+++ b/ui/mainwindow_grpc.cpp
@@ -285,8 +285,11 @@ void MainWindow::neko_start(int _id) {
     if (NekoGui::dataStore->prepare_exit) return;
 
     auto ents = get_now_selected_list();
+
+#ifdef Q_OS_LINUX
     if (IS_NEKO_BOX_INTERNAL_TUN)
         auto ret = Linux_Pkexec_SetCapString(NekoGui::FindNekoBoxCoreRealPath(), "cap_net_admin-ep");
+#endif
 
     auto ent = (_id < 0 && !ents.isEmpty()) ? ents.first() : NekoGui::profileManager->GetProfile(_id);
     if (ent == nullptr) return;

--- a/ui/mainwindow_grpc.cpp
+++ b/ui/mainwindow_grpc.cpp
@@ -288,7 +288,7 @@ void MainWindow::neko_start(int _id) {
 
 #ifdef Q_OS_LINUX
     if (IS_NEKO_BOX_INTERNAL_TUN)
-        auto ret = Linux_Pkexec_SetCapString(NekoGui::FindNekoBoxCoreRealPath(), "cap_net_admin-ep");
+        Linux_Pkexec_SetCapString(NekoGui::FindNekoBoxCoreRealPath(), "cap_net_admin-ep");
 #endif
 
     auto ent = (_id < 0 && !ents.isEmpty()) ? ents.first() : NekoGui::profileManager->GetProfile(_id);

--- a/ui/mainwindow_grpc.cpp
+++ b/ui/mainwindow_grpc.cpp
@@ -6,7 +6,6 @@
 #include "db/traffic/TrafficLooper.hpp"
 #include "rpc/gRPC.h"
 #include "ui/widget/MessageBoxTimer.h"
-#include "sys/linux/LinuxCap.h"
 
 #include <QTimer>
 #include <QThread>
@@ -286,10 +285,8 @@ void MainWindow::neko_start(int _id) {
 
     auto ents = get_now_selected_list();
 
-#ifdef Q_OS_LINUX
     if (IS_NEKO_BOX_INTERNAL_TUN)
-        Linux_Pkexec_SetCapString(NekoGui::FindNekoBoxCoreRealPath(), "cap_net_admin-ep");
-#endif
+        StopVPNProcess();
 
     auto ent = (_id < 0 && !ents.isEmpty()) ? ents.first() : NekoGui::profileManager->GetProfile(_id);
     if (ent == nullptr) return;

--- a/ui/mainwindow_grpc.cpp
+++ b/ui/mainwindow_grpc.cpp
@@ -6,6 +6,7 @@
 #include "db/traffic/TrafficLooper.hpp"
 #include "rpc/gRPC.h"
 #include "ui/widget/MessageBoxTimer.h"
+#include "sys/linux/LinuxCap.h"
 
 #include <QTimer>
 #include <QThread>
@@ -284,6 +285,9 @@ void MainWindow::neko_start(int _id) {
     if (NekoGui::dataStore->prepare_exit) return;
 
     auto ents = get_now_selected_list();
+    if (IS_NEKO_BOX_INTERNAL_TUN)
+        auto ret = Linux_Pkexec_SetCapString(NekoGui::FindNekoBoxCoreRealPath(), "cap_net_admin-ep");
+
     auto ent = (_id < 0 && !ents.isEmpty()) ? ents.first() : NekoGui::profileManager->GetProfile(_id);
     if (ent == nullptr) return;
 


### PR DESCRIPTION
切换节点时 `ip a` 的输出如下

https://github.com/MatsuriDayo/nekoray/assets/101881095/00aed516-d000-4095-8148-3dcd7330d0fc

基本上解决了 Linux 下切换节点时报错`start service: initialize inbound/tun[tun-in]: configure tun interface: device or resource busy`(issue #1139)的问题