### PR TITLE
ci: fixed pkgbuild for 4.0

### DIFF
--- a/.github/workflows/update-pkgbuild.yml
+++ b/.github/workflows/update-pkgbuild.yml
@@ -1,0 +1,18 @@
+name: AUR CI
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '!.github/workflows/**'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chitang233/aur-pkgbuild-builder@main
+        with:
+          deploy_key: ${{ secrets.DEPLOY_KEY }}
+          package_name: 'nekoray-git'


### PR DESCRIPTION
Added previous PKGBUILD CI back because I have already fixed broken assest paths.

The workflow won't succeed in my repo because there is nothing changed on upstream. Just merge and everything will work fine on next commit.