### PR TITLE
Add a button to remove duplicates across all profiles.

### DIFF
--- a/db/Database.cpp
+++ b/db/Database.cpp
@@ -14,6 +14,14 @@ namespace NekoGui {
         _add(new configItem("groups", &groupsTabOrder, itemType::integerList));
     }
 
+    QList<std::shared_ptr<ProxyEntity>> ProfileManager::Profiles() const {
+        QList<std::shared_ptr<ProxyEntity>> ret;
+        for (const auto &[_, profile]: profiles) {
+            ret += profile;
+        }
+        return ret;
+    }
+
     QList<int> filterIntJsonFile(const QString &path) {
         QList<int> result;
         QDir dr(path);

--- a/db/Database.hpp
+++ b/db/Database.hpp
@@ -28,6 +28,8 @@ namespace NekoGui {
 
         [[nodiscard]] static std::shared_ptr<Group> NewGroup();
 
+        QList<std::shared_ptr<ProxyEntity>> Profiles() const;
+
         bool AddProfile(const std::shared_ptr<ProxyEntity> &ent, int gid = -1);
 
         void DeleteProfile(int id);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -1358,11 +1358,12 @@ void MainWindow::on_menu_select_all_triggered() {
     ui->proxyListTable->selectAll();
 }
 
-void MainWindow::on_menu_delete_repeat_triggered() {
+void MainWindow::on_menu_delete_repeat_triggered(bool const search_across_all_profiles) {
     QList<std::shared_ptr<NekoGui::ProxyEntity>> out;
     QList<std::shared_ptr<NekoGui::ProxyEntity>> out_del;
 
-    NekoGui::ProfileFilter::Uniq(NekoGui::profileManager->CurrentGroup()->Profiles(), out, true, false);
+    auto const profiles = search_across_all_profiles ? NekoGui::profileManager->Profiles() : NekoGui::profileManager->CurrentGroup()->Profiles();
+    NekoGui::ProfileFilter::Uniq(profiles, out, true, false);
     NekoGui::ProfileFilter::OnlyInSrc_ByPointer(NekoGui::profileManager->CurrentGroup()->Profiles(), out, out_del);
 
     int remove_display_count = 0;
@@ -1382,6 +1383,10 @@ void MainWindow::on_menu_delete_repeat_triggered() {
         }
         refresh_proxy_list();
     }
+}
+
+void MainWindow::on_menu_delete_duplicates_global_triggered() {
+    return on_menu_delete_repeat_triggered(true);
 }
 
 bool mw_sub_updating = false;

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -121,7 +121,9 @@ private slots:
 
     void on_menu_select_all_triggered();
 
-    void on_menu_delete_repeat_triggered();
+    void on_menu_delete_repeat_triggered(bool const search_across_all_profiles = false);
+
+    void on_menu_delete_duplicates_global_triggered();
 
     void on_menu_remove_unavailable_triggered();
 

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -542,6 +542,7 @@
      <addaction name="separator"/>
      <addaction name="menu_remove_unavailable"/>
      <addaction name="menu_delete_repeat"/>
+     <addaction name="menu_delete_duplicates_global"/>
      <addaction name="separator"/>
      <addaction name="menu_update_subscription"/>
     </widget>
@@ -727,6 +728,14 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+D</string>
+   </property>
+  </action>
+  <action name="menu_delete_duplicates_global">
+   <property name="text">
+    <string>Remove Duplicates Across All Groups</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"></string>
    </property>
   </action>
   <action name="actionfake">


### PR DESCRIPTION
Added an option to remove profiles that already exist in other groups. This is useful for people who move certain profiles to a separate group and don't want them to get added again when pressing "Add profile from clipboard".