### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/3rdparty/qv2ray/v2/components/proxy/QvProxyConfigurator.cpp
+++ b/3rdparty/qv2ray/v2/components/proxy/QvProxyConfigurator.cpp
@@ -353,7 +353,7 @@ namespace Qv2ray::components::proxy {
             // execute and get the code
             const auto returnCode = QProcess::execute(action.first, action.second);
             // print out the commands and result codes
-            DEBUG(QString("[%1] Program: %2, Args: %3").arg(returnCode).arg(action.first).arg(action.second.join(";")));
+            DEBUG(QStringLiteral("[%1] Program: %2, Args: %3").arg(returnCode).arg(action.first).arg(action.second.join(";")));
             // give the code back
             results << (returnCode == QProcess::NormalExit);
         }
@@ -423,7 +423,7 @@ namespace Qv2ray::components::proxy {
             // execute and get the code
             const auto returnCode = QProcess::execute(action.first, action.second);
             // print out the commands and result codes
-            DEBUG(QString("[%1] Program: %2, Args: %3").arg(returnCode).arg(action.first).arg(action.second.join(";")));
+            DEBUG(QStringLiteral("[%1] Program: %2, Args: %3").arg(returnCode).arg(action.first).arg(action.second.join(";")));
         }
 
 #else

--- a/3rdparty/qv2ray/v2/ui/widgets/common/QJsonModel.cpp
+++ b/3rdparty/qv2ray/v2/ui/widgets/common/QJsonModel.cpp
@@ -191,13 +191,13 @@ QVariant QJsonModel::data(const QModelIndex &index, int role) const {
 
     if (role == Qt::DisplayRole) {
         if (index.column() == 0)
-            return QString("%1").arg(item->key());
+            return QStringLiteral("%1").arg(item->key());
 
         if (index.column() == 1)
-            return QString("%1").arg(item->value());
+            return QStringLiteral("%1").arg(item->value());
     } else if (Qt::EditRole == role) {
         if (index.column() == 1) {
-            return QString("%1").arg(item->value());
+            return QStringLiteral("%1").arg(item->value());
         }
     }
 

--- a/db/ConfigBuilder.cpp
+++ b/db/ConfigBuilder.cpp
@@ -76,7 +76,7 @@ namespace NekoGui {
     QString BuildChain(int chainId, const std::shared_ptr<BuildConfigStatus> &status) {
         auto group = profileManager->GetGroup(status->ent->gid);
         if (group == nullptr) {
-            status->result->error = QString("This profile is not in any group, your data may be corrupted.");
+            status->result->error = QStringLiteral("This profile is not in any group, your data may be corrupted.");
             return {};
         }
 
@@ -88,11 +88,11 @@ namespace NekoGui {
                 for (auto id: list) {
                     resolved += profileManager->GetProfile(id);
                     if (resolved.last() == nullptr) {
-                        status->result->error = QString("chain missing ent: %1").arg(id);
+                        status->result->error = QStringLiteral("chain missing ent: %1").arg(id);
                         break;
                     }
                     if (resolved.last()->type == "chain") {
-                        status->result->error = QString("chain in chain is not allowed: %1").arg(id);
+                        status->result->error = QStringLiteral("chain in chain is not allowed: %1").arg(id);
                         break;
                     }
                 }
@@ -109,7 +109,7 @@ namespace NekoGui {
         if (group->front_proxy_id >= 0) {
             auto fEnt = profileManager->GetProfile(group->front_proxy_id);
             if (fEnt == nullptr) {
-                status->result->error = QString("front proxy ent not found.");
+                status->result->error = QStringLiteral("front proxy ent not found.");
                 return {};
             }
             ents += resolveChain(fEnt);

--- a/db/Database.cpp
+++ b/db/Database.cpp
@@ -42,7 +42,7 @@ namespace NekoGui {
         // Load Proxys
         QList<int> delProfile;
         for (auto id: profilesIdOrder) {
-            auto ent = LoadProxyEntity(QString("profiles/%1.json").arg(id));
+            auto ent = LoadProxyEntity(QStringLiteral("profiles/%1.json").arg(id));
             // Corrupted profile?
             if (ent == nullptr || ent->bean == nullptr || ent->bean->version == -114514) {
                 delProfile << id;
@@ -58,7 +58,7 @@ namespace NekoGui {
         auto loadedOrder = groupsTabOrder;
         groupsTabOrder = {};
         for (auto id: groupsIdOrder) {
-            auto ent = LoadGroup(QString("groups/%1.json").arg(id));
+            auto ent = LoadGroup(QStringLiteral("groups/%1.json").arg(id));
             // Corrupted group?
             if (ent->id != id) {
                 continue;
@@ -103,7 +103,7 @@ namespace NekoGui {
                         auto newId = i++;
                         profile->id = newId;
                         profile->gid = gidOld2New[gid];
-                        profile->fn = QString("profiles/%1.json").arg(newId);
+                        profile->fn = QStringLiteral("profiles/%1.json").arg(newId);
                         profile->Save();
                         newProfiles[newId] = profile;
                         newProfilesIdOrder << newId;
@@ -122,7 +122,7 @@ namespace NekoGui {
                     auto group = groups[oldGid];
                     QFile::remove(group->fn);
                     group->id = newId;
-                    group->fn = QString("groups/%1.json").arg(newId);
+                    group->fn = QStringLiteral("groups/%1.json").arg(newId);
                     group->Save();
                     newGroups[newId] = group;
                     newGroupsIdOrder << newId;
@@ -227,7 +227,7 @@ namespace NekoGui {
         if (latency < 0) {
             return QObject::tr("Unavailable");
         } else if (latency > 0) {
-            return UNICODE_LRO + QString("%1 ms").arg(latency);
+            return UNICODE_LRO + QStringLiteral("%1 ms").arg(latency);
         } else {
             return "";
         }
@@ -268,7 +268,7 @@ namespace NekoGui {
         profiles[ent->id] = ent;
         profilesIdOrder.push_back(ent->id);
 
-        ent->fn = QString("profiles/%1.json").arg(ent->id);
+        ent->fn = QStringLiteral("profiles/%1.json").arg(ent->id);
         ent->Save();
         return true;
     }
@@ -278,7 +278,7 @@ namespace NekoGui {
         if (dataStore->started_id == id) return;
         profiles.erase(id);
         profilesIdOrder.removeAll(id);
-        QFile(QString("profiles/%1.json").arg(id)).remove();
+        QFile(QStringLiteral("profiles/%1.json").arg(id)).remove();
     }
 
     void ProfileManager::MoveProfile(const std::shared_ptr<ProxyEntity> &ent, int gid) {
@@ -342,7 +342,7 @@ namespace NekoGui {
         groupsIdOrder.push_back(ent->id);
         groupsTabOrder.push_back(ent->id);
 
-        ent->fn = QString("groups/%1.json").arg(ent->id);
+        ent->fn = QStringLiteral("groups/%1.json").arg(ent->id);
         ent->Save();
         return true;
     }
@@ -359,7 +359,7 @@ namespace NekoGui {
         groups.erase(gid);
         groupsIdOrder.removeAll(gid);
         groupsTabOrder.removeAll(gid);
-        QFile(QString("groups/%1.json").arg(gid)).remove();
+        QFile(QStringLiteral("groups/%1.json").arg(gid)).remove();
     }
 
     std::shared_ptr<Group> ProfileManager::GetGroup(int id) {

--- a/db/traffic/TrafficData.hpp
+++ b/db/traffic/TrafficData.hpp
@@ -29,12 +29,12 @@ namespace NekoGui_traffic {
         }
 
         [[nodiscard]] QString DisplaySpeed() const {
-            return UNICODE_LRO + QString("%1↑ %2↓").arg(ReadableSize(uplink_rate), ReadableSize(downlink_rate));
+            return UNICODE_LRO + QStringLiteral("%1↑ %2↓").arg(ReadableSize(uplink_rate), ReadableSize(downlink_rate));
         }
 
         [[nodiscard]] QString DisplayTraffic() const {
             if (downlink + uplink == 0) return "";
-            return UNICODE_LRO + QString("%1↑ %2↓").arg(ReadableSize(uplink), ReadableSize(downlink));
+            return UNICODE_LRO + QStringLiteral("%1↑ %2↓").arg(ReadableSize(uplink), ReadableSize(downlink));
         }
     };
 } // namespace NekoGui_traffic

--- a/fmt/AbstractBean.cpp
+++ b/fmt/AbstractBean.cpp
@@ -38,7 +38,7 @@ namespace NekoGui_fmt {
     }
 
     QString AbstractBean::DisplayTypeAndName() {
-        return QString("[%1] %2").arg(DisplayType(), DisplayName());
+        return QStringLiteral("[%1] %2").arg(DisplayType(), DisplayName());
     }
 
     void AbstractBean::ResolveDomainToIP(const std::function<void()> &onFinished) {

--- a/fmt/Bean2External.cpp
+++ b/fmt/Bean2External.cpp
@@ -9,7 +9,7 @@
 #define WriteTempFile(fn, data)                                   \
     QDir dir;                                                     \
     if (!dir.exists("temp")) dir.mkdir("temp");                   \
-    QFile f(QString("temp/") + fn);                               \
+    QFile f(QStringLiteral("temp/") + fn);                               \
     bool ok = f.open(QIODevice::WriteOnly | QIODevice::Truncate); \
     if (ok) {                                                     \
         f.write(data);                                            \

--- a/fmt/Bean2Link.cpp
+++ b/fmt/Bean2Link.cpp
@@ -13,7 +13,7 @@ namespace NekoGui_fmt {
                 url.setScheme("http");
             }
         } else {
-            url.setScheme(QString("socks%1").arg(socks_http_type));
+            url.setScheme(QStringLiteral("socks%1").arg(socks_http_type));
         }
         if (!name.isEmpty()) url.setFragment(name);
         if (!username.isEmpty()) url.setUserName(username);

--- a/main/HTTPRequestHelper.cpp
+++ b/main/HTTPRequestHelper.cpp
@@ -51,7 +51,7 @@ namespace NekoGui_network {
             for (const auto &err: errors) {
                 error_str << err.errorString();
             }
-            MW_show_log(QString("SSL Errors: %1 %2").arg(error_str.join(","), NekoGui::dataStore->sub_insecure ? "(Ignored)" : ""));
+            MW_show_log(QStringLiteral("SSL Errors: %1 %2").arg(error_str.join(","), NekoGui::dataStore->sub_insecure ? "(Ignored)" : ""));
         });
         // Wait for response
         auto abortTimer = new QTimer;

--- a/main/NekoGui.cpp
+++ b/main/NekoGui.cpp
@@ -349,7 +349,7 @@ namespace NekoGui {
     }
 
     QString Routing::DisplayRouting() const {
-        return QString("[Proxy] %1\n[Proxy] %2\n[Direct] %3\n[Direct] %4\n[Block] %5\n[Block] %6\n[Default Outbound] %7\n[DNS] %8")
+        return QStringLiteral("[Proxy] %1\n[Proxy] %2\n[Direct] %3\n[Direct] %4\n[Block] %5\n[Block] %6\n[Default Outbound] %7\n[DNS] %8")
             .arg(SplitLinesSkipSharp(proxy_domain).join(","), 10)
             .arg(SplitLinesSkipSharp(proxy_ip).join(","), 10)
             .arg(SplitLinesSkipSharp(direct_domain).join(","), 10)

--- a/main/NekoGui.hpp
+++ b/main/NekoGui.hpp
@@ -17,5 +17,5 @@ namespace NekoGui {
     bool IsAdmin();
 } // namespace NekoGui
 
-#define ROUTES_PREFIX_NAME QString("routes_box")
+#define ROUTES_PREFIX_NAME QStringLiteral("routes_box")
 #define ROUTES_PREFIX QString(ROUTES_PREFIX_NAME + "/")

--- a/rpc/gRPC.cpp
+++ b/rpc/gRPC.cpp
@@ -205,7 +205,7 @@ namespace NekoGui_rpc {
 
 #define NOT_OK      \
     *rpcOK = false; \
-    onError(QString("QNetworkReply::NetworkError code: %1\n").arg(status));
+    onError(QStringLiteral("QNetworkReply::NetworkError code: %1\n").arg(status));
 
     void Client::Exit() {
         libcore::EmptyReq request;

--- a/sys/windows/MiniDump.cpp
+++ b/sys/windows/MiniDump.cpp
@@ -56,7 +56,7 @@ LONG __stdcall CreateCrashHandler(EXCEPTION_POINTERS *pException) {
             }
             // 创建消息提示
             QMessageBox::warning(NULL, "Application crashed",
-                                 QString("ErrorCode: %1 ErrorAddr:%2 ErrorFlag: %3 ErrorPara: %4\nVersion: %5\nDump file at %6")
+                                 QStringLiteral("ErrorCode: %1 ErrorAddr:%2 ErrorFlag: %3 ErrorPara: %4\nVersion: %5\nDump file at %6")
                                      .arg(errCode)
                                      .arg(errAddr)
                                      .arg(errFlag)

--- a/ui/dialog_basic_settings.cpp
+++ b/ui/dialog_basic_settings.cpp
@@ -59,7 +59,7 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
 
     // Common
 
-    ui->log_level->addItems(QString("trace debug info warn error fatal panic").split(" "));
+    ui->log_level->addItems(QStringLiteral("trace debug info warn error fatal panic").split(" "));
     ui->mux_protocol->addItems({"h2mux", "smux", "yamux"});
 
     refresh_auth();

--- a/ui/dialog_manage_routes.cpp
+++ b/ui/dialog_manage_routes.cpp
@@ -25,7 +25,7 @@ DialogManageRoutes::DialogManageRoutes(QWidget *parent) : QDialog(parent), ui(ne
     //
     ui->outbound_domain_strategy->addItems(Preset::SingBox::DomainStrategy);
     ui->domainStrategyCombo->addItems(Preset::SingBox::DomainStrategy);
-    qsValue += QString("prefer_ipv4 prefer_ipv6 ipv4_only ipv6_only").split(" ");
+    qsValue += QStringLiteral("prefer_ipv4 prefer_ipv6 ipv4_only ipv6_only").split(" ");
     ui->dns_object->setPlaceholderText(DecodeB64IfValid("ewogICJzZXJ2ZXJzIjogW10sCiAgInJ1bGVzIjogW10sCiAgImZpbmFsIjogIiIsCiAgInN0cmF0ZWd5IjogIiIsCiAgImRpc2FibGVfY2FjaGUiOiBmYWxzZSwKICAiZGlzYWJsZV9leHBpcmUiOiBmYWxzZSwKICAiaW5kZXBlbmRlbnRfY2FjaGUiOiBmYWxzZSwKICAicmV2ZXJzZV9tYXBwaW5nIjogZmFsc2UsCiAgImZha2VpcCI6IHt9Cn0="));
     dnsHelpDocumentUrl = "https://sing-box.sagernet.org/configuration/dns/";
     //

--- a/ui/edit/edit_custom.cpp
+++ b/ui/edit/edit_custom.cpp
@@ -118,7 +118,7 @@ void EditCustom::onStart(std::shared_ptr<NekoGui::ProxyEntity> _ent) {
             auto command = QStringList{extR->program};
             command += extR->arguments;
             auto btn = QMessageBox::information(this, tr("Preview config"),
-                                                QString("Command: %1\n\n%2").arg(QStringList2Command(command), extR->config_export),
+                                                QStringLiteral("Command: %1\n\n%2").arg(QStringList2Command(command), extR->config_export),
                                                 "OK", "Copy", "", 0, 0);
             if (btn == 1) {
                 QApplication::clipboard()->setText(extR->config_export);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -478,7 +478,7 @@ void MainWindow::show_group(int gid) {
 
     auto group = NekoGui::profileManager->GetGroup(gid);
     if (group == nullptr) {
-        MessageBoxWarning(tr("Error"), QString("No such group: %1").arg(gid));
+        MessageBoxWarning(tr("Error"), QStringLiteral("No such group: %1").arg(gid));
         NekoGui::dataStore->refreshing_group = false;
         return;
     }
@@ -629,7 +629,7 @@ void MainWindow::on_commitDataRequest() {
     //
     if (!isMaximized()) {
         auto olds = NekoGui::dataStore->mw_size;
-        auto news = QString("%1x%2").arg(size().width()).arg(size().height());
+        auto news = QStringLiteral("%1x%2").arg(size().width()).arg(size().height());
         if (olds != news) {
             NekoGui::dataStore->mw_size = news;
         }
@@ -832,12 +832,12 @@ void MainWindow::refresh_status(const QString &traffic_update) {
 
     if (last_test_time.addSecs(2) < QTime::currentTime()) {
         auto txt = running == nullptr ? tr("Not Running")
-                                      : QString("[%1] %2").arg(group_name, running->bean->DisplayName()).left(30);
+                                      : QStringLiteral("[%1] %2").arg(group_name, running->bean->DisplayName()).left(30);
         ui->label_running->setText(txt);
     }
     //
     auto display_socks = DisplayAddress(NekoGui::dataStore->inbound_address, NekoGui::dataStore->inbound_socks_port);
-    auto inbound_txt = QString("Mixed: %1").arg(display_socks);
+    auto inbound_txt = QStringLiteral("Mixed: %1").arg(display_socks);
     ui->label_inbound->setText(inbound_txt);
     //
     ui->checkBox_VPN->setChecked(NekoGui::dataStore->spmode_vpn);
@@ -1167,7 +1167,7 @@ void MainWindow::on_menu_profile_debug_info_triggered() {
     if (ents.count() != 1) return;
     auto btn = QMessageBox::information(this, software_name, ents.first()->ToJsonBytes(), "OK", "Edit", "Reload", 0, 0);
     if (btn == 1) {
-        QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(QString("profiles/%1.json").arg(ents.first()->id)).absoluteFilePath()));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(QStringLiteral("profiles/%1.json").arg(ents.first()->id)).absoluteFilePath()));
     } else if (btn == 2) {
         NekoGui::dataStore->Load();
         NekoGui::profileManager->LoadManager();
@@ -1800,7 +1800,7 @@ bool MainWindow::StartVPNProcess() {
     //
     vpn_process->setProcessChannelMode(QProcess::ForwardedChannels);
 #ifdef Q_OS_MACOS
-    vpn_process->start("osascript", {"-e", QString("do shell script \"%1\" with administrator privileges")
+    vpn_process->start("osascript", {"-e", QStringLiteral("do shell script \"%1\" with administrator privileges")
                                                .arg("bash " + scriptPath)});
 #else
     vpn_process->start("pkexec", {"bash", scriptPath});
@@ -1823,7 +1823,7 @@ bool MainWindow::StopVPNProcess(bool unconditional) {
 #else
         QProcess p;
 #ifdef Q_OS_MACOS
-        p.start("osascript", {"-e", QString("do shell script \"%1\" with administrator privileges")
+        p.start("osascript", {"-e", QStringLiteral("do shell script \"%1\" with administrator privileges")
                                         .arg("pkill -2 -U 0 nekobox_core")});
 #else
         if (unconditional) {

--- a/ui/mainwindow_grpc.cpp
+++ b/ui/mainwindow_grpc.cpp
@@ -263,12 +263,12 @@ void MainWindow::speedtest_current() {
 
         runOnUiThread([=] {
             if (!result.error().empty()) {
-                MW_show_log(QString("UrlTest error: %1").arg(result.error().c_str()));
+                MW_show_log(QStringLiteral("UrlTest error: %1").arg(result.error().c_str()));
             }
             if (latency <= 0) {
                 ui->label_running->setText(tr("Test Result") + ": " + tr("Unavailable"));
             } else if (latency > 0) {
-                ui->label_running->setText(tr("Test Result") + ": " + QString("%1 ms").arg(latency));
+                ui->label_running->setText(tr("Test Result") + ": " + QStringLiteral("%1 ms").arg(latency));
             }
         });
     });


### PR DESCRIPTION
- Qt provides a macro [`QStringLiteral()`](https://doc.qt.io/qt-6/qstring.html#QStringLiteral), which makes constructing QString objects from string literals more efficient.